### PR TITLE
fix: preserve options with quoted strings

### DIFF
--- a/src/FFmpeggy.ts
+++ b/src/FFmpeggy.ts
@@ -8,6 +8,7 @@ import TypedEmitter from "typed-emitter";
 import { parseInfo, parseWriting, parseProgress } from "./parsers";
 import { FFmpeggyProgress } from "./types/FFmpeggyProgress";
 import { FFprobeResult } from "./types/probeTypes";
+import { parseOptions } from "./utils/parseOptions";
 
 export interface FFmpeggyOptions {
   cwd?: string;
@@ -155,10 +156,10 @@ export class FFmpeggy extends (EventEmitter as new () => TypedEmitter<FFmpegEven
     }
 
     const args = [
-      ...globalOptions.join(" ").split(" "),
-      ...inputOptions.join(" ").split(" "),
+      ...parseOptions(globalOptions),
+      ...parseOptions(inputOptions),
       ...["-i", ffmpegInput],
-      ...outputOptions.join(" ").split(" "),
+      ...parseOptions(outputOptions),
       ffmpegOutput,
     ].filter((a) => !!a);
 

--- a/src/utils/__tests__/parseOptions.spec.ts
+++ b/src/utils/__tests__/parseOptions.spec.ts
@@ -1,0 +1,46 @@
+import { parseOptions } from "../parseOptions";
+
+describe("parseOptions", () => {
+  it("should parse simple string array", () => {
+    const input = ["one two", "three"];
+    const expected = ["one", "two", "three"];
+    expect(parseOptions(input)).toEqual(expected);
+  });
+
+  it("should handle empty array", () => {
+    expect(parseOptions([])).toEqual([]);
+  });
+
+  it("should parse quoted strings correctly", () => {
+    const input = ['"hello world"', '"goodbye world"'];
+    const expected = ['"hello world"', '"goodbye world"'];
+    expect(parseOptions(input)).toEqual(expected);
+  });
+
+  it("should handle mixed quoted and unquoted strings", () => {
+    const input = ['simple "quoted value" unquoted'];
+    const expected = ["simple", '"quoted value"', "unquoted"];
+    expect(parseOptions(input)).toEqual(expected);
+  });
+
+  it("should handle empty strings", () => {
+    const input = [""];
+    expect(parseOptions(input)).toEqual([]);
+  });
+
+  it("should handle multiple spaces between options", () => {
+    const input = ["one    two     three"];
+    const expected = ["one", "two", "three"];
+    expect(parseOptions(input)).toEqual(expected);
+  });
+
+  it("should preserve quoted strings with spaces", () => {
+    const input = ['"this is one" "this    is    two"', "'this is three'"];
+    const expected = [
+      '"this is one"',
+      '"this    is    two"',
+      "'this is three'",
+    ];
+    expect(parseOptions(input)).toEqual(expected);
+  });
+});

--- a/src/utils/parseOptions.ts
+++ b/src/utils/parseOptions.ts
@@ -1,0 +1,15 @@
+/**
+ * Parses an array of option strings into an array of individual options.
+ *
+ * The `parseOptions` function takes an array of option strings and returns an array of individual options. It uses a regular expression to split each option string into its constituent parts, handling quoted strings and other non-whitespace tokens.
+ *
+ * @param options - An array of option strings to be parsed.
+ * @returns An array of individual options.
+ */
+const regex = /"[^"]*"|'[^']*'|\S+/g;
+export function parseOptions(options: string[]): string[] {
+  return options.flatMap((option) => {
+    const matches = option.match(regex);
+    return matches || [];
+  });
+}


### PR DESCRIPTION
This PR enhances the handling of options in ffmpeggy to ensure that quoted strings (both single and double quotes) are preserved in the parsed arguments. This resolves issues where options containing spaces would previously be split incorrectly.

Closes #557