### PR TITLE
fix: handle progress percentage when duration is not available

### DIFF
--- a/src/FFmpeggy.ts
+++ b/src/FFmpeggy.ts
@@ -306,12 +306,13 @@ export class FFmpeggy extends (EventEmitter as new () => TypedEmitter<FFmpegEven
           const progressEvent: FFmpeggyProgressEvent = {
             ...progress,
             duration,
-            percent: Math.min(
-              100,
-              progress.time
-                ? Math.round((progress.time / duration) * 100 * 100) / 100
-                : 0
-            ),
+            percent:
+              duration && duration > 0 && progress.time
+                ? Math.min(
+                    100,
+                    Math.round((progress.time / duration) * 100 * 100) / 100
+                  )
+                : 0,
           };
           debug("progress: %o", progressEvent);
           this.emit("progress", progressEvent);

--- a/src/__tests__/parsers.spec.ts
+++ b/src/__tests__/parsers.spec.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { parseProgress, parseFinalSizes, parseInfo } from "../parsers";
 
+function calculateProgressPercentage(
+  progressTime: number | undefined,
+  duration: number | undefined
+): number {
+  return duration && duration > 0 && progressTime
+    ? Math.min(100, Math.round((progressTime / duration) * 100 * 100) / 100)
+    : 0;
+}
+
 describe("parsers", () => {
   it("should parse simple progress", () => {
     const txt =
@@ -202,15 +211,8 @@ describe("parsers", () => {
       expect(progress).toBeDefined();
       expect(progress?.time).toBe(154.08);
 
-      // Simulate the percentage calculation from FFmpeggy.ts
       const duration = 300; // 5 minutes
-      const percent =
-        duration && duration > 0 && progress?.time
-          ? Math.min(
-              100,
-              Math.round((progress.time / duration) * 100 * 100) / 100
-            )
-          : 0;
+      const percent = calculateProgressPercentage(progress?.time, duration);
 
       expect(percent).toBe(51.36); // (154.08 / 300) * 100
     });
@@ -222,15 +224,8 @@ describe("parsers", () => {
       expect(progress).toBeDefined();
       expect(progress?.time).toBe(154.08);
 
-      // Simulate the percentage calculation when duration is 0
       const duration = 0;
-      const percent =
-        duration && progress?.time
-          ? Math.min(
-              100,
-              Math.round((progress.time / duration) * 100 * 100) / 100
-            )
-          : 0;
+      const percent = calculateProgressPercentage(progress?.time, duration);
 
       expect(percent).toBe(0);
     });
@@ -242,15 +237,8 @@ describe("parsers", () => {
       expect(progress).toBeDefined();
       expect(progress?.time).toBe(154.08);
 
-      // Simulate the percentage calculation when duration is undefined
       const duration = undefined;
-      const percent =
-        duration && duration > 0 && progress?.time
-          ? Math.min(
-              100,
-              Math.round((progress.time / duration) * 100 * 100) / 100
-            )
-          : 0;
+      const percent = calculateProgressPercentage(progress?.time, duration);
 
       expect(percent).toBe(0);
     });
@@ -262,15 +250,8 @@ describe("parsers", () => {
       expect(progress).toBeDefined();
       expect(progress?.time).toBeUndefined();
 
-      // Simulate the percentage calculation when time is not available
       const duration = 300;
-      const percent =
-        duration && duration > 0 && progress?.time
-          ? Math.min(
-              100,
-              Math.round((progress.time / duration) * 100 * 100) / 100
-            )
-          : 0;
+      const percent = calculateProgressPercentage(progress?.time, duration);
 
       expect(percent).toBe(0);
     });

--- a/src/__tests__/parsers.spec.ts
+++ b/src/__tests__/parsers.spec.ts
@@ -193,4 +193,86 @@ describe("parsers", () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe("progress percentage calculation", () => {
+    it("should calculate correct percentage when duration is available", () => {
+      const progress = parseProgress(
+        "frame= 3853 fps=246 q=-1.0 size=   25202kB time=00:02:34.08 bitrate=1339.9kbits/s speed=9.82x"
+      );
+      expect(progress).toBeDefined();
+      expect(progress?.time).toBe(154.08);
+
+      // Simulate the percentage calculation from FFmpeggy.ts
+      const duration = 300; // 5 minutes
+      const percent =
+        duration && duration > 0 && progress?.time
+          ? Math.min(
+              100,
+              Math.round((progress.time / duration) * 100 * 100) / 100
+            )
+          : 0;
+
+      expect(percent).toBe(51.36); // (154.08 / 300) * 100
+    });
+
+    it("should return 0 when duration is not available", () => {
+      const progress = parseProgress(
+        "frame= 3853 fps=246 q=-1.0 size=   25202kB time=00:02:34.08 bitrate=1339.9kbits/s speed=9.82x"
+      );
+      expect(progress).toBeDefined();
+      expect(progress?.time).toBe(154.08);
+
+      // Simulate the percentage calculation when duration is 0
+      const duration = 0;
+      const percent =
+        duration && duration > 0 && progress?.time
+          ? Math.min(
+              100,
+              Math.round((progress.time / duration) * 100 * 100) / 100
+            )
+          : 0;
+
+      expect(percent).toBe(0);
+    });
+
+    it("should return 0 when duration is undefined", () => {
+      const progress = parseProgress(
+        "frame= 3853 fps=246 q=-1.0 size=   25202kB time=00:02:34.08 bitrate=1339.9kbits/s speed=9.82x"
+      );
+      expect(progress).toBeDefined();
+      expect(progress?.time).toBe(154.08);
+
+      // Simulate the percentage calculation when duration is undefined
+      const duration = undefined;
+      const percent =
+        duration && duration > 0 && progress?.time
+          ? Math.min(
+              100,
+              Math.round((progress.time / duration) * 100 * 100) / 100
+            )
+          : 0;
+
+      expect(percent).toBe(0);
+    });
+
+    it("should return 0 when progress time is not available", () => {
+      const progress = parseProgress(
+        "frame= 3853 fps=246 q=-1.0 size=   25202kB bitrate=1339.9kbits/s speed=9.82x"
+      );
+      expect(progress).toBeDefined();
+      expect(progress?.time).toBeUndefined();
+
+      // Simulate the percentage calculation when time is not available
+      const duration = 300;
+      const percent =
+        duration && duration > 0 && progress?.time
+          ? Math.min(
+              100,
+              Math.round((progress.time / duration) * 100 * 100) / 100
+            )
+          : 0;
+
+      expect(percent).toBe(0);
+    });
+  });
 });

--- a/src/__tests__/parsers.spec.ts
+++ b/src/__tests__/parsers.spec.ts
@@ -225,7 +225,7 @@ describe("parsers", () => {
       // Simulate the percentage calculation when duration is 0
       const duration = 0;
       const percent =
-        duration && duration > 0 && progress?.time
+        duration && progress?.time
           ? Math.min(
               100,
               Math.round((progress.time / duration) * 100 * 100) / 100

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -4,7 +4,7 @@ import { parseSize } from "./utils/parseSize";
 import { timerToSecs } from "./utils/timerToSecs";
 
 const progressRxp =
-  /(?:frame=\s*(?<frame>[\d]+)\s+)?(?:fps=\s*(?<fps>[\d.]+)\s+)?(?:q=(?<q>[0-9.-]+)\s+)?(L?)size=\s*(?<size>[0-9]+|N\/A)(?<sizeunit>kB|mB|b)?\s*time=\s*(?<time>\d\d:\d\d:\d\d\.\d\d)\s*bitrate=\s*(?<bitrate>N\/A|[\d.]+)(?<bitrateunit>bits\/s|mbits\/s|kbits\/s)?.*(dup=(?<duplicates>\d+)\s*)?(drop=(?<dropped>\d+)\s*)?speed=\s*(?<speed>[\d.e+]+)x/;
+  /(?:frame=\s*(?<frame>[\d]+)\s+)?(?:fps=\s*(?<fps>[\d.]+)\s+)?(?:q=(?<q>[0-9.-]+)\s+)?(L?)size=\s*(?<size>[0-9]+|N\/A)(?<sizeunit>kB|mB|b)?\s*(?:time=\s*(?<time>\d\d:\d\d:\d\d\.\d\d)\s*)?bitrate=\s*(?<bitrate>N\/A|[\d.]+)(?<bitrateunit>bits\/s|mbits\/s|kbits\/s)?.*(dup=(?<duplicates>\d+)\s*)?(drop=(?<dropped>\d+)\s*)?speed=\s*(?<speed>[\d.e+]+)x/;
 export function parseProgress(data: string): FFmpeggyProgress | undefined {
   const matches = progressRxp.exec(data);
   if (!matches || !matches.groups) {


### PR DESCRIPTION
This pull request enhances the handling of progress percentage calculations in the `FFmpeggy` module, ensuring robustness when duration or progress time is unavailable. It also updates related tests and parsing logic to reflect these changes.

### Enhancements to progress percentage calculation:
- **`src/FFmpeggy.ts`**: Modified the logic for calculating `percent` in the `progressEvent` object to handle cases where `duration` or `progress.time` is undefined or zero. This prevents invalid values like `100%` when data is incomplete.

### Updates to tests:
- **`src/__tests__/FFmpeggy.events.test.ts`**:
  - Added validation in existing tests to ensure `percent` is correctly set to `0` when `duration` is unavailable.
  - Introduced two new test cases:
    - One for handling progress when `duration` is unavailable during file-to-file operations.
    - Another for handling progress during streaming operations where `duration` might not be available.
- **`src/__tests__/parsers.spec.ts`**: Added a new test suite for verifying progress percentage calculations under various conditions, including when `duration` or `time` is missing.

### Improvements to parsing logic:
- **`src/parsers.ts`**: Updated the `progressRxp` regex to make the `time` field optional, ensuring compatibility with cases where `time` is not present in the progress data.

### Test utilities:
- **`src/__tests__/FFmpeggy.events.test.ts`**: Added `StreamHelpers` to support streaming-related tests.

Closes #26